### PR TITLE
Ajuste no retorno do end-point de criação de QrCode dinâmico

### DIFF
--- a/apis/v1/pix/schema.yaml
+++ b/apis/v1/pix/schema.yaml
@@ -1013,11 +1013,14 @@ paths:
       responses:
         '200':
           description: Recurso criado com sucesso.
-          headers:
-            x-bkly-correlation-id:
-              description: Id correlação da operação requisitada.
+          content:
+            application/json:
               schema:
-                type: string
+                type: object
+                properties:
+                  encodedValue:
+                    description: QR Code codificado em base64.
+                    type: string
         '400':
           $ref: 'http://localhost:3320/commons/components#/components/responses/400'
       security:


### PR DESCRIPTION
de acordo com a documentação para criação de QrCode dinâmico o retorno é o mesmo que retorna o estático. por isso está solicitação de correção.

documentações em:
https://docs.bankly.com.br/docs/pix-emissao-qrcode-dinamico
https://docs.bankly.com.br/docs/pix-emissao-qrcode